### PR TITLE
include Kuma Control Plane into Docker Compose setup

### DIFF
--- a/kuma-dataplane/platform/uni/bookinfo/.env
+++ b/kuma-dataplane/platform/uni/bookinfo/.env
@@ -1,0 +1,4 @@
+#
+# Default values for variables in `docker-compose.yaml` files
+#
+KUMA_CONTROL_PLANE_API_SERVER_URL=http://kuma-control-plane:5681

--- a/kuma-dataplane/platform/uni/bookinfo/README.md
+++ b/kuma-dataplane/platform/uni/bookinfo/README.md
@@ -1,0 +1,129 @@
+# Book Info
+
+## How To Run
+
+1. Start `Kuma` Control Plane, create `Dataplanes` and generate tokens:
+
+   ```shell
+   docker-compose -f docker-compose-kuma-cp.yaml up -d
+   ```
+
+   Notice that `Kuma REST API` will be exposed on the host machine as [localhost:5681](http://localhost:5681) to support usage of `kumactl`.
+
+2. Verify that `Dataplanes` have been created:
+
+   ```shell
+   kumactl get dataplanes
+
+   MESH      NAME               TAGS
+   default   dp-productpage-1   service=productpage version=1.0
+   default   dp-details-1       service=details version=1.0
+   default   dp-reviews-1       service=reviews version=1.0
+   default   dp-rating-1        service=rating version=1.0
+   ```
+
+3. Verify that dataplane tokens have been generated:
+
+   ```shell
+   ls -1 ../secrets/
+
+   dp-details-1
+   dp-productpage-1
+   dp-rating-1
+   dp-reviews-1
+   ```
+
+4. Start `productpage` service:
+
+   ```shell
+   docker-compose -f docker-compose-productpage.yaml up -d
+   ```
+
+   Notice that `Book Info` application will be exposed on the host machine as [localhost:9080](http://localhost:9080/productpage?u=normal).
+
+5. Start `details` service:
+
+   ```shell
+   docker-compose -f docker-compose-details.yaml up -d
+   ```
+
+6. Start `reviews` service:
+
+   ```shell
+   docker-compose -f docker-compose-reviews.yaml up -d
+   ```
+
+7. Start `ratings` service:
+
+   ```shell
+   docker-compose -f docker-compose-ratings.yaml up -d
+   ```
+
+8. Verify that `mTLS` is not enabled yet:
+
+   ```shell
+   kumactl get meshes
+
+   NAME      mTLS   CA        METRICS
+   default   off    builtin   off
+   ```
+
+   Notice that `mTLS` is `off`.
+
+9. Validate that `Book Info` application is up-and-running:
+
+   ```shell
+   open http://localhost:9080/productpage?u=normal
+   ```
+
+   Notice both details and reviews information on [the page](http://localhost:9080/productpage?u=normal).
+
+10. Enable `mTLS`:
+
+    ```shell
+    kumactl apply -f mesh/default+mtls.mesh.yaml
+    ```
+
+    ```shell
+    kumactl get meshes
+
+    NAME      mTLS   CA        METRICS
+    default   on     builtin   off
+    ```
+
+    Notice that `mTLS` is `on`.
+
+11. Verify that traffic between `productpage` and other services is no longer allowed:
+
+    ```shell
+    open http://localhost:9080/productpage?u=normal
+    ```
+
+    2 error messages must appear on [the page](open http://localhost:9080/productpage?u=normal):
+
+    * `Error fetching product details!`
+    * `Error fetching product reviews!`
+
+12. Enable traffic between all services:
+
+    ```shell
+    kumactl apply -f traffic-permission/tp-allow-all.yaml
+    ```
+
+13. Verify that traffic between `productpage` and other services is now allowed:
+
+    ```shell
+    open http://localhost:9080/productpage?u=normal
+    ```
+
+    Notice both details and reviews information on [the page](http://localhost:9080/productpage?u=normal).
+
+## How To Cleanup
+
+```shell
+docker-compose -f docker-compose-ratings.yaml down
+docker-compose -f docker-compose-reviews.yaml down
+docker-compose -f docker-compose-details.yaml down
+docker-compose -f docker-compose-productpage.yaml down
+docker-compose -f docker-compose-kuma-cp.yaml down
+```

--- a/kuma-dataplane/platform/uni/bookinfo/docker-compose-details.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/docker-compose-details.yaml
@@ -7,7 +7,8 @@ services:
     ports:
       - "29081:29081" #expose the envoy port to host
     networks:
-      - mesh
+      mesh:
+        ipv4_address: 192.168.16.4
     restart: on-failure
 
   # deploy sidecar along side with service
@@ -19,7 +20,7 @@ services:
     volumes:
       - ../secrets/dp-details-1:/var/kuma.io/kuma-dp/dp-details-1/token
     environment:
-      - KUMA_CONTROL_PLANE_API_SERVER_URL={KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}      
+      - KUMA_CONTROL_PLANE_API_SERVER_URL=${KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}
       - KUMA_DATAPLANE_MESH=default
       - KUMA_DATAPLANE_NAME=dp-details-1
       - KUMA_DATAPLANE_ADMIN_PORT=9901

--- a/kuma-dataplane/platform/uni/bookinfo/docker-compose-kuma-cp.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/docker-compose-kuma-cp.yaml
@@ -1,0 +1,61 @@
+version: "3.5"
+
+services:
+  #
+  # Kuma Control Plane in "universal" mode with "in-memory" configuration store.
+  #
+  kuma-control-plane:
+    # image name must be provided via environment variable KUMA_CP_DOCKER_IMAGE
+    image: ${KUMA_CP_DOCKER_IMAGE:-kong-docker-kuma-docker.bintray.io/kuma-cp:latest}
+    command:
+    - run
+    - --log-level=info
+    environment:
+    # DNS name of the Kuma xDS server
+    - KUMA_GENERAL_ADVERTISED_HOSTNAME=kuma-control-plane
+    expose:
+    - "5678"
+    - "5679"
+    - "5680"
+    - "5681"
+    - "5682"
+    - "5683"
+    - "5684"
+    ports:
+    - "5681:5681" # allow usage of `kumactl` on the host machine
+    networks:
+      mesh:
+        ipv4_address: 192.168.16.200
+        aliases:
+        - kuma-control-plane
+    restart: on-failure
+
+  #
+  # Setup script for Book Info example.
+  #
+  # Uses `kumactl` to create Dataplane resources, generate dataplane tokens, etc.
+  #
+  kuma-setup-book-info:
+    # image name must be provided via environment variable KUMACTL_DOCKER_IMAGE
+    image: ${KUMACTL_DOCKER_IMAGE:-kong-docker-kuma-docker.bintray.io/kumactl:latest}
+    volumes:
+    - ./kuma-setup-book-info.sh:/kuma/kuma-setup-book-info.sh
+    - ./dataplane:/kuma/dataplanes
+    - ../secrets:/kuma/tokens
+    environment:
+    - INPUT_DATAPLANE_DIR=/kuma/dataplanes
+    - OUTPUT_TOKEN_DIR=/kuma/tokens
+    command:
+      - /kuma/kuma-setup-book-info.sh
+    network_mode: service:kuma-control-plane
+    depends_on:
+      - kuma-control-plane
+    restart: on-failure
+
+networks:
+  mesh:
+    ipam:
+      driver: default
+      config:
+      # use static IPs to simplify setup workflow
+      - subnet: "192.168.16.0/24"

--- a/kuma-dataplane/platform/uni/bookinfo/docker-compose-productpage.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/docker-compose-productpage.yaml
@@ -6,8 +6,10 @@ services:
     image: berinle/examples-bookinfo-productpage-v1:latest
     ports:
       - "49081:49081" #expose the envoy port to host
+      - "9080:9080"
     networks:
-      - mesh
+      mesh:
+        ipv4_address: 192.168.16.5
     environment:
       - DETAILS_HOSTNAME=127.0.0.1
       - RATINGS_HOSTNAME=127.0.0.1
@@ -26,7 +28,7 @@ services:
     volumes:
       - ../secrets/dp-productpage-1:/var/kuma.io/kuma-dp/dp-productpage-1/token
     environment:
-      - KUMA_CONTROL_PLANE_API_SERVER_URL={KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}      
+      - KUMA_CONTROL_PLANE_API_SERVER_URL=${KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}
       - KUMA_DATAPLANE_MESH=default
       - KUMA_DATAPLANE_NAME=dp-productpage-1
       - KUMA_DATAPLANE_ADMIN_PORT=9901

--- a/kuma-dataplane/platform/uni/bookinfo/docker-compose-ratings.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/docker-compose-ratings.yaml
@@ -7,7 +7,8 @@ services:
     ports:
       - "39081:39081"
     networks:
-      - mesh
+      mesh:
+        ipv4_address: 192.168.16.2
     environment:
       - ENABLE_RATINGS=true
     restart: on-failure
@@ -21,7 +22,7 @@ services:
     volumes:
       - ../secrets/dp-rating-1:/var/kuma.io/kuma-dp/dp-rating-1/token
     environment:
-      - KUMA_CONTROL_PLANE_API_SERVER_URL={KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}      
+      - KUMA_CONTROL_PLANE_API_SERVER_URL=${KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}
       - KUMA_DATAPLANE_MESH=default
       - KUMA_DATAPLANE_NAME=dp-rating-1
       - KUMA_DATAPLANE_ADMIN_PORT=9901

--- a/kuma-dataplane/platform/uni/bookinfo/docker-compose-reviews.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/docker-compose-reviews.yaml
@@ -7,7 +7,8 @@ services:
     ports:
       - "19081:19081" #expose the envoy port to host
     networks:
-      - mesh
+      mesh:
+        ipv4_address: 192.168.16.3
     environment:
       - RATINGS_HOSTNAME=127.0.0.1
       - RATINGS_PORT=39082
@@ -23,7 +24,7 @@ services:
     volumes:
       - ../secrets/dp-reviews-1:/var/kuma.io/kuma-dp/dp-reviews-1/token
     environment:
-      - KUMA_CONTROL_PLANE_API_SERVER_URL={KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}      
+      - KUMA_CONTROL_PLANE_API_SERVER_URL=${KUMA_CONTROL_PLANE_API_SERVER_URL:-http://localhost:5681}
       - KUMA_DATAPLANE_MESH=default
       - KUMA_DATAPLANE_NAME=dp-reviews-1
       - KUMA_DATAPLANE_ADMIN_PORT=9901

--- a/kuma-dataplane/platform/uni/bookinfo/kuma-setup-book-info.sh
+++ b/kuma-dataplane/platform/uni/bookinfo/kuma-setup-book-info.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "${INPUT_DATAPLANE_DIR}" ]; then
+  echo "Error: environment variable INPUT_DATAPLANE_DIR is not set"
+  exit 1
+fi
+
+if [ -z "${OUTPUT_TOKEN_DIR}" ]; then
+  echo "Error: environment variable OUTPUT_TOKEN_DIR is not set"
+  exit 1
+fi
+
+#
+# Utility functions
+#
+
+function create_dataplane {
+  DATAPLANE_NAME="$1"
+  DATAPLANE_IP="$2"
+  DATAPLANE_RESOURCE="$3"
+
+  echo "Creating dataplane '${DATAPLANE_NAME}' ..."
+
+  echo "${DATAPLANE_RESOURCE}" | kumactl apply --var DATA_PLANE_IP="${DATAPLANE_IP}" -f "${INPUT_DATAPLANE_DIR}/${DATAPLANE_RESOURCE}"
+
+  echo "Generating dataplane token for '${DATAPLANE_NAME}' ..."
+
+  mkdir -p "${OUTPUT_TOKEN_DIR}"
+  kumactl generate dataplane-token --dataplane "${DATAPLANE_NAME}" --mesh default >"${OUTPUT_TOKEN_DIR}/${DATAPLANE_NAME}"
+}
+
+#
+# Create dataplanes and generate tokens
+#
+
+create_dataplane dp-productpage-1 192.168.16.5 dp-productpage-v1.yaml
+create_dataplane dp-details-1     192.168.16.4 dp-details-v1.yaml
+create_dataplane dp-reviews-1     192.168.16.3 dp-reviews-v1.yaml
+create_dataplane dp-rating-1      192.168.16.2 dp-rating-v1.yaml

--- a/kuma-dataplane/platform/uni/bookinfo/mesh/default+metrics.mesh.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/mesh/default+metrics.mesh.yaml
@@ -1,0 +1,4 @@
+type: Mesh
+name: default
+metrics:
+  prometheus: {}

--- a/kuma-dataplane/platform/uni/bookinfo/mesh/default+mtls+metrics.mesh.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/mesh/default+mtls+metrics.mesh.yaml
@@ -1,0 +1,8 @@
+type: Mesh
+name: default
+metrics:
+  prometheus: {}
+mtls:
+  enabled: true
+  ca:
+    builtin: {}

--- a/kuma-dataplane/platform/uni/bookinfo/mesh/default+mtls.mesh.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/mesh/default+mtls.mesh.yaml
@@ -1,0 +1,6 @@
+type: Mesh
+name: default
+mtls:
+  enabled: true
+  ca:
+    builtin: {}

--- a/kuma-dataplane/platform/uni/bookinfo/mesh/default.mesh.yaml
+++ b/kuma-dataplane/platform/uni/bookinfo/mesh/default.mesh.yaml
@@ -1,0 +1,2 @@
+type: Mesh
+name: default


### PR DESCRIPTION
## Summary

* include `Kuma Control Plane` into Docker Compose setup
* update network configuration to use static IPs
* create `Dataplanes` and generate dataplane tokens on Control Plane start up
* provide instructions how to start `Book Info` application, how to enable `mTLS`, how to apply `TrafficPermissions`
